### PR TITLE
Add meter data support for the zwave on/off switches.

### DIFF
--- a/steward/devices/devices-gateway/gateway-openzwave-usb.js
+++ b/steward/devices/devices-gateway/gateway-openzwave-usb.js
@@ -130,7 +130,13 @@ var scan1 = function(driver) {
                                , serialNo     : driver.serialNumber
                                });
 
-  zwave = new openzwave(comName, { saveconfig: true });
+  zwave = new openzwave(comName, {
+    saveconfig: true,
+    suppressrefresh: true,
+    driverattempts: 3,
+    pollinterval: 500
+  });
+
   scanning[comName] = zwave;
   zwave.on('driver ready', function(homeid) {
     zwave.on('node added', function(nodeid) {

--- a/steward/devices/devices-switch/switch-zwave-onoff.js
+++ b/steward/devices/devices-switch/switch-zwave-onoff.js
@@ -45,6 +45,7 @@ var ZWave_OnOff = exports.Device = function(deviceID, deviceUID, info) {
   });
 
   self.driver.enablePoll(self.peripheral.nodeid, 0x25);
+  self.driver.enablePoll(self.peripheral.nodeid, 0x32);
 };
 util.inherits(ZWave_OnOff, plug.Device);
 
@@ -54,6 +55,12 @@ ZWave_OnOff.prototype.update = function(self, event, comclass, value) {
 
   var f = { 'value changed' :
               function() {
+                var meterData = self.peripheral.classes[0x32];
+                if (!!meterData) {
+                  if (!!meterData[0]) self.info.dailyUsage = +meterData[0]['value'] / 1000;
+                  if (!!meterData[8]) self.info.currentUsage = +meterData[8]['value'];
+                }
+
                 if (!self.peripheral.classes[comclass]) self.peripheral.classes[comclass] = {};
                 self.peripheral.classes[comclass][value.index] = value;
                 if ((comclass !== 0x25) || (value.index !== 0)) return;


### PR DESCRIPTION
This pull request is released under the MIT license.

Check if the device has meter capabilities and is emitting the information and record it in the device’s `info` section.

Also changed the `openzwave` configuration and added options supported in `v0.0.32`.
