### PR TITLE
Add wind and rain to telldus live.

### DIFF
--- a/steward/devices/devices-gateway/gateway-telldus-live-cloud.js
+++ b/steward/devices/devices-gateway/gateway-telldus-live-cloud.js
@@ -170,8 +170,13 @@ Cloud.prototype.getSensor = function(self, offset) {
 
     if (!!err) return logger.error('device/' + self.deviceID, { event: 'getSensor', offset: offset, diagnostic: err.message });
 
-    props =  { temp     : [ 'temperature', 'celcius',    'meteo' ]
-             , humidity : [ 'humidity',    'percentage', 'meteo' ]
+    props =  { temp     : [ 'temperature',   'celcius',    'meteo' ]
+             , humidity : [ 'humidity',      'percentage', 'meteo' ]
+	     , rrate    : [ 'rainRate',      'mm/h',       'meteo' ]
+	     , rtot     : [ 'rainTotal',     'mm',         'meteo' ]
+	     , wavg     : [ 'windAverage',   'm/s',        'meteo' ]
+	     , wgust    : [ 'windGust',      'm/s',        'meteo' ]
+	     , wdir     : [ 'windDirection', 'degrees',    'meteo' ]
              };
 
     data = { lastSample: params.lastUpdated * 1000 };

--- a/steward/sandbox/console.html
+++ b/steward/sandbox/console.html
@@ -614,7 +614,23 @@ var onactors = function(message) {
               break;
 
             case 'waterLevel':
+            case 'rainTotal':
               if (!isNaN(v)) v = v.toFixed(2) + 'mm';
+              break;
+
+            case 'rainRate':
+              if (!isNaN(v)) v = v.toFixed(2) + 'mm';
+              break;
+
+            case 'windAverage':
+            case 'windGust':
+              if (!isNaN(v)) v = v.toFixed(2) + 'm/s';
+              break;
+
+	    // FIXME: should be available in both cardinal directions and in azimuth degrees???
+	    // http://en.wikipedia.org/wiki/Wind_direction
+            case 'windDirection':
+              if (!isNaN(v)) v = v.toFixed(1) + '&deg;';
               break;
 
             case 'battery':

--- a/steward/sandbox/d3/drilldown.js
+++ b/steward/sandbox/d3/drilldown.js
@@ -1018,6 +1018,10 @@ var single_climate_instructions = function(device) {
 };
 
 
+var azimuth2cardinal = function(deg) {
+  var _directions = ["N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE", "S", "SSW", "SW", "WSW", "W", "WNW", "NW", "NNW"];
+  return _directions[Math.floor((deg % 360) / 22.5)];
+};
 
 var climate_device_arcs = function(device) {
   var arcs, i, metric, now, prop, props, v;
@@ -1034,7 +1038,9 @@ var climate_device_arcs = function(device) {
                                                       'needsMist',       'rssi'
                                  , 'hvac',            'noise',           'co',       'concentration', 'nextSample',
                                                       'needsFertilizer', 'battery',  'batteryLevel',  'location'
-                                 , 'away',             'pressure',       'no2'
+                                 , 'away',            'pressure',        'no2'
+				 , 'rainRate',        'rainTotal'
+				 , 'windAverage',     'windGust',        'windDirection'
                                  ]);
 
   for (i = 0; i < props.length; i++) {
@@ -1086,6 +1092,27 @@ var climate_device_arcs = function(device) {
                           , index  : 0.60
                           });
         break;
+
+      case 'rainRate':
+        arcs.splice(1, 0, { name   : prop
+                          , raw    : v
+                          , label  : 'RAIN RATE'
+                          , cooked : v.toFixed(2) + 'mm/h'
+                          , value  : clip2bars(v, 0, 200)
+                          , index  : 0.50
+                          });
+        break;
+
+      case 'windAverage':
+        arcs.splice(1, 0, { name   : prop
+                          , raw    : v
+                          , label  : 'WIND AVERAGE'
+                          , cooked : v.toFixed(2) + 'm/s'
+                          , value  : clip2bars(v, 0, 50)
+                          , index  : 0.50
+                          });
+        break;
+
 
 
 // 2nd ring
@@ -1156,6 +1183,25 @@ var climate_device_arcs = function(device) {
                           , label  : 'CONDITIONS'
                           , cooked : v
                           , value  : clip2bars(v.length ? 100 : 0, 0, 100)
+                          , index  : 0.50
+                          });
+        break;
+      case 'rainTotal':
+        arcs.splice(2, 0, { name   : prop
+                          , raw    : v
+                          , label  : 'RAIN TOTAL'
+                          , cooked : v.toFixed(2) + 'mm'
+                          , value  : clip2bars(v, 0, 1000)
+                          , index  : 0.50
+                          });
+        break;
+
+      case 'windGust':
+        arcs.splice(2, 0, { name   : prop
+                          , raw    : v
+                          , label  : 'WIND GUST'
+                          , cooked : v.toFixed(2) + 'm/s'
+                          , value  : clip2bars(v, 0, 50)
                           , index  : 0.50
                           });
         break;
@@ -1233,6 +1279,15 @@ var climate_device_arcs = function(device) {
                           });
         break;
 
+      case 'windDirection':
+        arcs.splice(3, 0, { name   : prop
+                          , raw    : v
+                          , label  : 'WIND DIRECTION'
+                          , cooked : azimuth2cardinal(v) + ' (' + v.toFixed(0) + '&deg;)'
+                          , value  : clip2bars(v, 0, 360)
+                          , index  : 0.40
+                          });
+        break;
 
 // 4th ring
       case 'hvac':

--- a/steward/sandbox/d3/voice.js
+++ b/steward/sandbox/d3/voice.js
@@ -207,13 +207,15 @@ All recognized commands without filter\n\
                                                      perform(entry.entry, entry.phrases['off'].text, 'off');                      };
 
       return { climate_control : function(entry) { if (entry.phrases['report'].selected) 
-                                                     report(entry.entry,  [ 'temperature', 'humidity'                 ], entry.phrases['report'].text);              }
+                                                     report(entry.entry,  [ 'temperature', 'humidity'                                ], entry.phrases['report'].text);              }
              , climate_plant   : function(entry) { if (entry.phrases['report'].selected) 
-                                                     report(entry.entry,  [ 'status', 'needsWater', 'needsMist', 'needsFertilizer' ], entry.phrases['report'].text); }
+                                                     report(entry.entry,  [ 'status', 'needsWater', 'needsMist', 'needsFertilizer'   ], entry.phrases['report'].text);              }
              , climate_soil    : function(entry) { if (entry.phrases['report'].selected) 
                                                      report(entry.entry,  [ 'temperature', 'moisture', 'waterVolume', 'light'        ], entry.phrases['report'].text);              }
              , climate_meteo   : function(entry) { if (entry.phrases['report'].selected) 
-                                                     report(entry.entry,  [ 'temperature', 'humidity', 'noise', 'co2' ], entry.phrases['report'].text);              }
+                                                     report(entry.entry,  [ 'temperature', 'humidity', 'noise', 'co2' , 'rainRate', 'rainTotal', 
+						                            'windAverage', 'windGust','windDirection'                ], entry.phrases['report'].text);              }
+
              , lighting_bulb       : lighting
              , lighting_downlight  : lighting
              , lighting_lightstrip : lighting


### PR DESCRIPTION
Pull request redone (replacing #225), not to touch the Oregon Scientific driver. 

In the console it is still listed under /device/climate/oregon-scientific/meteo  but I assume that is because telldus-live reports the protocol used as oregon.

Still missing icons for rain and wind. 

Please review carefully!
