### PR TITLE
Make sure parameter is not null either.

### DIFF
--- a/steward/devices/devices-gateway/gateway-insteon-automategreen.js
+++ b/steward/devices/devices-gateway/gateway-insteon-automategreen.js
@@ -90,7 +90,7 @@ Gateway.prototype.scan = function(self) {
 
       if (!!err) return logger.error('device/' + self.deviceID, { event: 'links', diagnostic: err.message });
 
-      if (typeof links === 'undefined') return;
+      if (typeof links === 'undefined' || typeof links === null) return;
 
       var f = function(id) {
         return function(err, info) {


### PR DESCRIPTION
Sometimes "links" parameter is null.

Supporting error message:

```
alert: [steward] exception diagnostic=Cannot read property 'length' of null
alert: [steward] exception stack=[{"fileName":"/home/pi/steward/steward/devices/devices-gateway/gateway-insteon-automategreen.js","lineNumber":103,"functionName":null,"typeName":null,"methodName":null,"columnNumber":28,"native":false},{"fileName":"/home/pi/steward/steward/node_modules/home-controller/node_modules/q/q.js","lineNumber":1887,"functionName":null,"typeName":null,"methodName":null,"columnNumber":17,"native":false},{"fileName":"/home/pi/steward/steward/node_modules/home-controller/node_modules/q/q.js","lineNumber":108,"functionName":"flush","typeName":"Object","methodName":null,"columnNumber":17,"native":false},{"fileName":"node.js","lineNumber":419,"functionName":"process._tickCallback","typeName":"process","methodName":"_tickCallback","columnNumber":13,"native":false}]
uncaught exception: TypeError: Cannot read property 'length' of null
```
