### PR TITLE
Fix #244

### DIFF
--- a/steward/devices/devices-climate/climate-samsung-control.js
+++ b/steward/devices/devices-climate/climate-samsung-control.js
@@ -269,7 +269,11 @@ Thermostat.prototype.perform = function(self, taskID, perform, parameter) {
   if (!Thermostat.operations[perform]) return devices.perform(self, taskID, perform, parameter);
 
   Thermostat.operations[perform](this, params);
-  setTimeout(function () { self.gateway.scan(self); }, 1 * 1000);
+  setTimeout(function () {
+    if (self.gateway) {
+      self.gateway.scan(self); 
+    }
+  }, 1 * 1000);
   return steward.performed(taskID);
 };
 


### PR DESCRIPTION
Fix #244

```
alert: [steward] exception diagnostic=Cannot call method 'scan' of undefined
alert: [steward] exception stack=[{"fileName":"/home/pi/steward/steward/devices/devices-climate/climate-samsung-control.js","lineNumber":286,"functionName":"null._onTimeout","typeName":"null","methodName":"_onTimeout","columnNumber":41,"native":false},{"fileName":"[as ontimeout] (timers.js","lineNumber":110,"functionName":"Timer.listOnTimeout","typeName":"Timer","methodName":"listOnTimeout","columnNumber":15,"native":false}]
uncaught exception: TypeError: Cannot call method 'scan' of undefined
```
