### PR TITLE
Telldus dimmable devices

### DIFF
--- a/steward/devices/devices-switch/switch-telldus-dimmer.js
+++ b/steward/devices/devices-switch/switch-telldus-dimmer.js
@@ -122,6 +122,15 @@ Dimmer.prototype.perform = function(self, taskID, perform, parameter) {
     self.update(self, self.params);
   });
 
+  // Really turn it off. Otherwise it is still considered to be on but with level=0
+  if (perform === 'off') {
+    self.gateway.telldus.onOffDevice(self.params, false, function(err, results) {
+      if ((!err) && (!!results) && (!!results.error)) err = new Error(results.error);
+      if (!!err) return logger.error('device/' + self.deviceID, { event: 'onOffDevice', diagnostic: err.message });
+    });
+  }
+
+
   return steward.performed(taskID);
 };
 


### PR DESCRIPTION
Fixes #206. Finally nailed the Telldus dimmable devices issues. 

Perhaps  when turning a dimmable device on the onOffDevice method should be used instead of setting the level, the drawback doing that is that there is no way for the Steward to know which level the dimmable device is at (neither does Telldus live know). 

If  a device is turned off, the next time you turn it sets the level to the level it was at when it was turned off. Does not work if the Steward is restarted though.
