### PR TITLE
Fixes #110

### DIFF
--- a/steward/devices/devices-gateway/gateway-openzwave-usb.js
+++ b/steward/devices/devices-gateway/gateway-openzwave-usb.js
@@ -145,15 +145,15 @@ var scan1 = function(driver) {
     }).on('node ready', function(nodeid, nodeinfo) {
       var comclass, info, oops, props, udn;
 
+      udn = 'openzwave:' + homeid.toString(16) + ':' + nodeid;
+      if (!!devices.devices[udn]) return;
+
       props = utility.clone(nodeinfo);
       props.homeid = homeid.toString(16);
       props.nodeid = nodeid;
       oops = utility.clone(props);
       props.classes = nodes[nodeid].classes;
       nodes[nodeid] = props;
-
-      udn = 'openzwave:' + homeid.toString(16) + ':' + nodeid;
-      if (!!devices.devices[udn]) return;
 
       info = { source: comName, driver: zwave, peripheral: nodes[nodeid] };
       info.device = { url          : null


### PR DESCRIPTION
Every time, a z-wave device sends a "I'm ready"-Event, the local map entry of this node is re-written.
Thats because a too late abort statement, which should check, if this node is already initialized. As an effect, the Device object instance is getting lost and the `value changes`-Event can't be handled anymore.
