### PR TITLE
Ignoring all project files of Jetbrains IntelliJ IDEA and WebStorm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ zwcfg_*.xml
 
 .node-xmlhttprequest-*
 typescript
+
+.idea
+*.iml


### PR DESCRIPTION
As I think that I'm not the only developer with a jetbrains product, please add this to the .gitignore file.
